### PR TITLE
Improve Dependency Downloading in Dockerfile

### DIFF
--- a/build/docker-riscv/Dockerfile
+++ b/build/docker-riscv/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /opt/cartesi/share
 
 COPY dependencies .
 COPY shasumfile .
-RUN while read DEP; do wget -O $DEP; done < dependencies
+RUN while read -r NAME URL; do wget -O "$NAME" "$URL"; done < dependencies
 RUN sha1sum -c shasumfile
 
 


### PR DESCRIPTION
Current Behavior:
Currently, the Dockerfile uses the following command to download dependencies:
`RUN while read DEP; do wget -O $DEP; done < dependencies`

Error:
------
 > [fs machine-core 6/6] RUN sha1sum -c shasumfile:
0.282 rom.bin: OK
0.282 sha1sum: can't open 'linux.bin': No such file or directory
0.293 linux.bin: FAILED
0.293 machine-emulator-tools.tar.gz: OK
0.293 sha1sum: WARNING: 1 of 3 computed checksums did NOT match
------
Dockerfile:15
--------------------
  13 |     COPY shasumfile .
  14 |     RUN while read DEP; do wget -O $DEP; done < dependencies
  15 | >>> RUN sha1sum -c shasumfile
  16 |     
  17 |     
--------------------
ERROR: failed to solve: process "/bin/sh -c sha1sum -c shasumfile" did not complete successfully: exit code: 1

-------------------------------------------------------------------

This command expects each line in the dependencies file to be a URL. However, the -O option in wget is used to specify the local file name that the remote file should be saved as. Without specifying the remote file URL, this command could potentially fail or lead to unexpected behaviors.

Proposed Change:
Modify the dependency downloading command to accommodate a dependency file that contains both the file name and the URL. The suggested modification is:

`RUN while read -r NAME URL; do wget -O "$NAME" "$URL"; done < dependencies`

With this change, the dependencies file should contain pairs of file names and URLs, allowing each downloaded file to be saved with a specific name.

